### PR TITLE
Introduces a lookup trick to speed up simulation computation

### DIFF
--- a/stats/src/lisa.rs
+++ b/stats/src/lisa.rs
@@ -1,6 +1,6 @@
 use geo_weights::weights::{TransformType, Weights};
 use nalgebra::DVector;
-use rand::seq::{SliceRandom, IteratorRandom, index::sample};
+use rand::seq::index::sample;
 use rayon::prelude::*;
 use serde::Serialize;
 
@@ -8,16 +8,23 @@ use serde::Serialize;
 pub struct LISAResult {
     pub moran_val: Vec<f64>,
     pub quads: Vec<Quad>,
+    pub lags: Vec<f64>,
     pub p_vals: Vec<f64>,
     pub sims: Vec<Vec<f64>>,
 }
 
+/// Specifies the permutation method to use when performing significance tests 
+/// if it's FULL we calculate a random conditional permutation of the observations for every single
+/// simulation draw
+/// If it's LOOKUP, we generate a set of permutaitons ahead of time corrisoponding to each set of
+/// no of neighbors and then this is used as a look up when performing the simulation.
 #[derive(Debug, Serialize)]
 pub enum PermutationMethod{
     FULL,
     LOOKUP
 }
 
+/// Moran Quad definitions
 #[derive(Debug, Serialize)]
 pub enum Quad {
     HH,
@@ -26,20 +33,26 @@ pub enum Quad {
     LL,
 }
 
+/// Generates a nested set of vectors which contain permuted indices for each of the different
+/// number of neighbors that we have in the set. These are used to speed up selection of neighbors
+/// during the simulation phase of lisa generation
 pub fn generate_perturbation_lookups( max_no_neighbors: usize, permutations:usize, no_observations: usize)-> Vec<Vec<Vec<usize>>>{
-    let lookup: Vec<Vec<Vec<usize>>> = (0..max_no_neighbors+1).into_par_iter().map(|no_neighbors|{
+    (0..max_no_neighbors+1).into_par_iter().map(|no_neighbors|{
         let mut rng = rand::thread_rng();
-        let inner_lookup: Vec<Vec<usize>> = (0..permutations).map(|_|{
-            let sample = sample(&mut rng, no_observations-1, no_neighbors).into_vec();
-            sample
-        }).collect();
-        inner_lookup
-    }).collect();
-    println!("Lookup dim 1: {} 2: {} 3: {} observations {}", lookup.len(), lookup[0].len(), lookup[0][0].len(), no_observations);
-    lookup
+        (0..permutations).map(|_|{
+            sample(&mut rng, no_observations-1, no_neighbors).into_vec()
+        }).collect()
+    }).collect()
 }
 
 
+/// Computes the LISA stats for the given weights and values. Results are a LisaResult object that
+/// contains the 
+/// - moran_values: for each observation
+/// - lags: the lag value for each observation
+/// - quads: the moran quad specification for each observation, 
+/// - p_vals: the estimated p_val of each observation 
+/// - sims: the simulated moran values for each observation if keep_sims is specified
 pub fn lisa(weights: &Weights, values: &[f64], permutations: usize, keep_sims: bool, permutation_method: PermutationMethod) -> LISAResult {
     let x = DVector::from_column_slice(values);
     let no_observations = x.len();
@@ -117,13 +130,19 @@ pub fn lisa(weights: &Weights, values: &[f64], permutations: usize, keep_sims: b
 
             let p_val = (larger as f64 + 1.0) / (permutations as f64 + 1.0);
 
-            (p_val, sim_vals)
+            if keep_sims{
+                (p_val, sim_vals)
+            }
+            else{
+                (p_val,vec![])
+            }
         })
         .collect();
 
     LISAResult {
         moran_val: results.data.into(),
         quads,
+        lags: lags.data.into(),
         sims: sim_results.iter().map(|r| r.1.clone()).collect(),
         p_vals: sim_results.iter().map(|r| r.0).collect(),
     }

--- a/stats/src/main.rs
+++ b/stats/src/main.rs
@@ -1,0 +1,30 @@
+use geo::GeometryCollection;
+use geo_stats::lisa::{lisa, PermutationMethod};
+use geo_weights::{QueensWeights, WeightBuilder};
+use geojson::GeoJson;
+
+fn main(){
+
+        let jsonfile = std::fs::read_to_string(format!(
+            "{}/{}",
+            std::env::var("CARGO_MANIFEST_DIR").unwrap(),
+            "test_data/covid.geojson"
+        ))
+        .unwrap();
+        let geojson: GeoJson = jsonfile.parse().unwrap();
+        let geoms: GeometryCollection<f64> = geojson::quick_collection(&geojson).unwrap();
+        let weight_builder = QueensWeights::new(10000.0);
+        let weights = weight_builder.compute_weights(&geoms.0);
+
+        if let GeoJson::FeatureCollection(fc) = geojson {
+            let values: Vec<f64> = fc
+                .features
+                .iter()
+                .map(|f| f.property("cases").unwrap().as_f64().unwrap())
+                .collect();
+
+                lisa(&weights, &values, 9999, false, PermutationMethod::LOOKUP);
+        } else {
+            panic!("Expected data to be a feature collection")
+        }
+}

--- a/stats/tests/lisa.rs
+++ b/stats/tests/lisa.rs
@@ -3,7 +3,7 @@
 extern crate test;
 
 use geo::{polygon, Geometry, GeometryCollection};
-use geo_stats::lisa::lisa;
+use geo_stats::lisa::{lisa,PermutationMethod};
 use geo_weights::{QueensWeights, WeightBuilder, Weights};
 use geojson::{quick_collection, FeatureCollection, GeoJson};
 use std::collections::{HashMap, HashSet};
@@ -15,7 +15,7 @@ use test::{black_box, Bencher};
 extern crate approx;
 
 #[test]
-fn lisa_should_produce_correct_values() {
+fn lisa_should_produce_correct_values_using_full_permutation() {
     let mut values: Vec<f64> = vec![
         2.24, 3.1, 4.55, -5.15, -4.39, 0.46, 5.54, 9.02, -2.09, -3.06,
     ];
@@ -35,7 +35,48 @@ fn lisa_should_produce_correct_values() {
 
     let weights = Weights::new(dict, 10, HashSet::new());
 
-    let moran = lisa(&weights, &values, 9999, true);
+    let moran = lisa(&weights, &values, 9999, true, PermutationMethod::FULL);
+    let expected: Vec<f64> = vec![
+        -0.11409277104439629,
+        -0.19940542567754874,
+        -0.13351408484935268,
+        -0.5177038320446772,
+        0.480950090494397,
+        0.12208113114030265,
+        0.18876001422853794,
+        -0.5814430454766123,
+        0.07101382808078055,
+        0.3431430079934854,
+    ];
+
+    relative_eq!(moran.moran_val.iter().sum::<f64>(), expected.iter().sum());
+
+    let j = serde_json::to_string(&moran).unwrap();
+    let mut file = File::create("results.json").unwrap();
+}
+
+#[test]
+fn lisa_should_produce_correct_values_using_lookup_permutation() {
+    let mut values: Vec<f64> = vec![
+        2.24, 3.1, 4.55, -5.15, -4.39, 0.46, 5.54, 9.02, -2.09, -3.06,
+    ];
+
+    let mut dict: HashMap<usize, HashMap<usize, f64>> = HashMap::new();
+
+    dict.insert(0, HashMap::from([(1, 1.0), (3, 1.0)]));
+    dict.insert(1, HashMap::from([(0, 1.0), (4, 1.0)]));
+    dict.insert(2, HashMap::from([(3, 1.0), (6, 1.0)]));
+    dict.insert(3, HashMap::from([(0, 1.0), (2, 1.0), (4, 1.0), (7, 1.0)]));
+    dict.insert(4, HashMap::from([(1, 1.0), (3, 1.0), (5, 1.0), (8, 1.0)]));
+    dict.insert(5, HashMap::from([(4, 1.0), (9, 1.0)]));
+    dict.insert(6, HashMap::from([(2, 1.0), (7, 1.0)]));
+    dict.insert(7, HashMap::from([(3, 1.0), (6, 1.0), (8, 1.0)]));
+    dict.insert(8, HashMap::from([(4, 1.0), (7, 1.0), (9, 1.0)]));
+    dict.insert(9, HashMap::from([(5, 1.0), (8, 1.0)]));
+
+    let weights = Weights::new(dict, 10, HashSet::new());
+
+    let moran = lisa(&weights, &values, 9999, true,PermutationMethod::LOOKUP);
     let expected: Vec<f64> = vec![
         -0.11409277104439629,
         -0.19940542567754874,
@@ -75,7 +116,7 @@ fn real_data() {
             .map(|f| f.property("Donatns").unwrap().as_f64().unwrap())
             .collect();
 
-        let lisa_results = lisa(&weights, &values, 9999, false);
+        let lisa_results = lisa(&weights, &values, 9999, false,PermutationMethod::LOOKUP);
         println!("{:#?}, {:#?}", lisa_results.moran_val, lisa_results.p_vals);
         let j = serde_json::to_string(&lisa_results).unwrap();
         let mut file = File::create("results_real.json").unwrap();


### PR DESCRIPTION
Instead of computing a random permutation of observations for each point in each simulation iteration, we instead generate a lookup of the shape [max_no_neighbors, no_permutations, no_neighbors]  with type usize. This means instead of having to reshuffle or resample the observations each permutation and observation, we can simple knock out the target observation, lookup the number of indices we need for the neighbors and work through each permutation that has been cached.

This should change the sampling part of the simulation from something like O(no_observations*no_permutations) to  O(max_no_weights*no_permutations).
