### PR TITLE
Iter based weight generation

### DIFF
--- a/weights/Cargo.toml
+++ b/weights/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geo-weights"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Stuart Lynn <stuart.lynn@gmail.com>"]
 edition = "2018"
 description = "Crate for generating weights matrixes from geospatial data."

--- a/weights/src/weights.rs
+++ b/weights/src/weights.rs
@@ -2,7 +2,7 @@ use geo::{Centroid, GeoFloat, Line};
 use geo_types::Geometry;
 use geojson::{Feature, FeatureCollection};
 use nalgebra_sparse::{coo::CooMatrix, csr::CsrMatrix};
-use std::collections::HashMap;
+use std::collections::{HashMap,HashSet};
 use std::fmt;
 
 pub enum TransformType {
@@ -19,7 +19,8 @@ where
     where for<'a> &'a T: IntoIterator<Item=&'a Geometry<A>>;
 }
 
-// A is the precision of the Geometry
+/// Structure holding and providing methods to access and query a weights matrix. These are either
+/// loaded from extenal representations or constructed from WeightBuilders.
 #[derive(Debug)]
 pub struct Weights {
     weights: HashMap<usize, HashMap<usize, f64>>,
@@ -33,6 +34,15 @@ impl fmt::Display for Weights {
 }
 
 impl Weights {
+    /// Create a new weights object from a hashmap indicating origin and destination ids and
+    /// weights.
+    ///
+    /// # Arguments
+    ///
+    /// * `weights` - A mapping of {origin => dest =>weight}f64
+    /// * `no_elements` - The number of elements in the original geometry set (because we want to be
+    /// sure of the full length given this is a sparse representation)
+    ///
     pub fn new(
         weights: HashMap<usize, HashMap<usize, f64>>,
         no_elements: usize,
@@ -43,28 +53,82 @@ impl Weights {
         }
     }
 
+    /// Create a new weights object from a series of lists representing the origin, destinations
+    /// and weights of the matrix 
+    ///
+    /// # Arguments
+    ///
+    /// * `origins` - A  list of the origin ids
+    /// * `origins` - A  list of the destination ids 
+    /// * `weights` - A  list of the weights 
+    /// * `no_elements` - The number of elements in the original geometry set (because we want to be
+    /// sure of the full length given this is a sparse representation)
+    ///
+    pub fn from_list_rep(
+        origins: &Vec<usize>,
+        dests: &Vec<usize>,
+        weights: &Vec<f64>,
+        no_elements: usize
+    ) -> Weights{
+        let mut weights_lookup: HashMap<usize,HashMap<usize,f64>>= HashMap::new();
+
+      for (index,origin) in origins.iter().enumerate(){
+         let entry = weights_lookup.entry(*origin).or_insert(HashMap::new());
+         entry.insert(dests[index], weights[index]);
+
+         let entry = weights_lookup.entry(dests[index]).or_insert(HashMap::new());
+         entry.insert(*origin, weights[index]);
+      }
+      Self{
+       weights: weights_lookup,
+       no_elements
+      }
+    }
+
+    /// Return a reference to the hash map representation of the weights
     pub fn weights(&self) -> &HashMap<usize, HashMap<usize, f64>> {
         &self.weights
     }
 
+    /// Return the total number of elements in the original geometry set
     pub fn no_elements(&self) -> usize {
         self.no_elements
     }
 
+    /// Returns true if the origin and destination are neighbors 
+    ///
+    /// # Arguments
+    /// 
+    /// * `origin` - the id of the origin geometry
+    /// * `destination` - the id of the destination geometry
+    ///
     pub fn are_neighbors(&self, origin: usize, dest: usize) -> bool {
         self.weights.get(&origin).unwrap().contains_key(&dest)
     }
 
-    pub fn get_neighbor_ids(&self, origin: usize) -> Option<Vec<usize>> {
+    /// Returns the ids of a given geometries neighbors 
+    ///
+    /// # Arguments
+    /// 
+    /// * `origin` - the id of the origin geometry
+    ///
+    pub fn get_neighbor_ids(&self, origin: usize) -> Option<HashSet<usize>> {
         match self.weights.get(&origin) {
             Some(m) => {
-                let results: Vec<usize> = m.keys().into_iter().cloned().collect();
+                let results: HashSet<usize> = m.keys().into_iter().cloned().collect();
                 Some(results)
             }
             None => None,
         }
     }
 
+    /// Returns the weights matrix as a nalgebra sparse matrix 
+    ///
+    /// # Arguments
+    /// 
+    /// * `transfrom` - what transform, if any to apply to the weights matrix as we  transform.
+    /// Only TransformType::Row for row normalized is currently implemented.
+    ///
     pub fn as_sparse_matrix(&self, transform: Option<TransformType>) -> CsrMatrix<f64> {
         let mut coo_matrix = CooMatrix::new(self.no_elements, self.no_elements);
 
@@ -81,6 +145,59 @@ impl Weights {
         CsrMatrix::from(&coo_matrix)
     }
 
+    /// Returns the weights matrix in a list format 
+    ///
+    /// Output format is a tuple of origin ids, dest ids, weight values
+    ///
+    pub fn to_list(&self)->(Vec<usize>, Vec<usize>, Vec<f64>){
+        let mut origin_list: Vec<usize> = vec![];
+        let mut dest_list: Vec<usize>= vec![];
+        let mut weight_list: Vec<f64>= vec![];
+
+        for (origin, dests) in self.weights.iter() {
+            for (dest, weight) in dests.iter() {
+                origin_list.push(*origin);
+                dest_list.push(*dest);
+                weight_list.push(*weight);
+            }
+        }
+        (origin_list,dest_list,weight_list)
+    }
+
+    /// Returns the weights matrix in a list format with geometries 
+    ///
+    /// Output format is a tuple of origin ids, dest ids, weight values, geometry linking origin
+    /// and destination
+    ///
+    /// # Arguments
+    /// 
+    /// * `geoms` - the list of geometries originally used to generate the weights matrix.
+    pub fn to_list_with_geom<A:GeoFloat>(&self, geoms: &[Geometry<A>])->(Vec<usize>, Vec<usize>, Vec<f64>, Vec<Geometry<A>>){
+        let mut origin_list: Vec<usize> = vec![];
+        let mut dest_list: Vec<usize>= vec![];
+        let mut weight_list: Vec<f64>= vec![];
+        let mut geoms: Vec<Geometry<A>> = vec![];
+
+        for (origin, dests) in self.weights.iter() {
+            for (dest, weight) in dests.iter() {
+                origin_list.push(*origin);
+                dest_list.push(*dest);
+                weight_list.push(*weight);
+                let origin_centroid = geoms.get(*origin).unwrap().centroid().unwrap();
+                let dest_centroid = geoms.get(*dest).unwrap().centroid().unwrap();
+                let line: geo::Geometry<A> = geo::Geometry::Line(Line::new(origin_centroid, dest_centroid));
+                geoms.push(line);
+            }
+        }
+        (origin_list,dest_list,weight_list, geoms)
+    }
+
+    /// Returns the weights matrix in a GeoJson format with lines between the origin and
+    /// destinations 
+    ///
+    /// # Arguments
+    /// 
+    /// * `geoms` - the list of geometries originally used to generate the weights matrix.
     pub fn links_geojson<A: GeoFloat>(&self, geoms: &[Geometry<A>]) -> FeatureCollection {
         let mut features: Vec<Feature> = vec![];
 

--- a/weights/tests/weights.rs
+++ b/weights/tests/weights.rs
@@ -45,3 +45,39 @@ fn we_should_correctly_construct_a_matrix_from_list_representation() {
     assert_eq!(n4, Some(HashSet::from([3,2])));
     assert_eq!(n5, Some(HashSet::from([2])));
 }
+
+#[test]
+fn we_should_be_able_to_save_and_load_list_reps() {
+
+    let origins: Vec<usize> = vec![
+        1,
+        1,
+        3,
+        4,
+        5
+    ];
+
+    let dests: Vec<usize> = vec![
+        2,
+        3,
+        4,
+        2,
+        2
+    ];
+
+    let weights: Vec<f64> = vec![
+        1.0,
+        2.0,
+        -1.0,
+        2.0,
+        1.0
+    ];
+
+    let weights = Weights::from_list_rep(origins, dests, weights, 5);
+
+    let (origins, dests, weight_vals)= weights.to_list();
+
+    let weights2 = Weights::from_list_rep(origins,dests,weight_vals,5);
+
+    assert_eq!(weights.weights(), weights2.weights());
+}

--- a/weights/tests/weights.rs
+++ b/weights/tests/weights.rs
@@ -1,0 +1,47 @@
+use geo_weights::Weights;
+use std::collections::HashSet;
+#[test]
+fn we_should_correctly_construct_a_matrix_from_list_representation() {
+
+    let origins: Vec<usize> = vec![
+        1,
+        1,
+        3,
+        4,
+        5
+    ];
+
+    let dests: Vec<usize> = vec![
+        2,
+        3,
+        4,
+        2,
+        2
+    ];
+
+    let weights: Vec<f64> = vec![
+        1.0,
+        2.0,
+        -1.0,
+        2.0,
+        1.0
+    ];
+
+    let weights = Weights::from_list_rep(&origins, &dests, &weights, 5);
+
+    let n0 = weights.get_neighbor_ids(0);
+    let n1 = weights.get_neighbor_ids(1);
+    let n2 = weights.get_neighbor_ids(2);
+    let n3 = weights.get_neighbor_ids(3);
+    let n4 = weights.get_neighbor_ids(4);
+    let n5 = weights.get_neighbor_ids(5);
+
+    assert!(n0.is_none());
+    assert_eq!(n1, Some(HashSet::from([2,3])));
+    assert_eq!(n2, Some(HashSet::from([5,1,4])));
+    assert_eq!(n3, Some(HashSet::from([1,4])));
+    assert_eq!(n3, Some(HashSet::from([1,4])));
+    assert_eq!(n3, Some(HashSet::from([1,4])));
+    assert_eq!(n4, Some(HashSet::from([3,2])));
+    assert_eq!(n5, Some(HashSet::from([2])));
+}


### PR DESCRIPTION
- Switches to using Trait Bounds on weight generation 
- Adds methods to generate weights from list representations
- Adds methods to generate a list representation from weights.
